### PR TITLE
Update s3-wagon plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
 <build>
   <extensions>
     <extension>
-      <groupId>org.kuali.maven.wagons</groupId>
+      <groupId>com.github.seahen</groupId>
       <artifactId>maven-s3-wagon</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.0</version>
     </extension>
   </extensions>
 </build>


### PR DESCRIPTION
Following this case [here](https://github.com/jcaddel/maven-s3-wagon/issues/42) there is issues regarding the AWS S3 API.

This other option is working in my case after June 24, 2019.

Thanks for the work !